### PR TITLE
Resort multi-network interfaces to make lo/eth0 first

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -26,6 +26,8 @@ func init() {
 
 var cmd, protocol, sockAddr, ifprefix, dbname string
 
+var UseMultiNet bool
+
 const DEFAULT_IFPREFIX = "eth"
 const DEFAULT_DBNAME = "net.db"
 
@@ -37,6 +39,7 @@ func main() {
 	flag.StringVar(&sockAddr, "address", "/tmp/kni.sock", "socket address")
 	flag.StringVar(&ifprefix, "ifprefix", "eth", "interface prefix")
 	flag.StringVar(&dbname, "dbname", "net.db", "boltdb file name")
+	flag.BoolVar(&UseMultiNet, "usemultinet", true, "use multi network features")
 
 	flag.Parse()
 
@@ -70,7 +73,13 @@ func run() error {
 
 	server := grpc.NewServer()
 
-	kni, err := cniservice.NewKniService(ifprefix, dbname)
+	config := cniservice.KNIConfig{
+		IfPrefix:    ifprefix,
+		Db:          dbname,
+		UseMultiNet: UseMultiNet,
+	}
+
+	kni, err := cniservice.NewKniService(&config)
 
 	if err != nil {
 		log.Fatal(err)

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.21.5
 require (
 	github.com/MikeZappa87/kni-api v0.0.5
 	github.com/containerd/go-cni v1.1.9
+	github.com/fsnotify/fsnotify v1.7.0
 	github.com/sirupsen/logrus v1.9.3
 	go.etcd.io/bbolt v1.3.8
 	google.golang.org/grpc v1.58.3
@@ -12,7 +13,6 @@ require (
 
 require (
 	github.com/containernetworking/cni v1.1.2 // indirect
-	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/onsi/ginkgo/v2 v2.6.1 // indirect
@@ -24,3 +24,5 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230822172742-b8732ec3820d // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
 )
+
+replace github.com/containerd/go-cni => github.com/mikezappa87/go-cni v1.1.1-0.20240114032345-d4b1b5a94b43

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,6 @@ github.com/MikeZappa87/kni-api v0.0.5/go.mod h1:5A4mnixcyfsk8Xuw7awf5zbxig+GZGio
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
-github.com/containerd/go-cni v1.1.9 h1:ORi7P1dYzCwVM6XPN4n3CbkuOx/NZ2DOqy+SHRdo9rU=
-github.com/containerd/go-cni v1.1.9/go.mod h1:XYrZJ1d5W6E2VOvjffL3IZq0Dz6bsVlERHbekNK90PM=
 github.com/containernetworking/cni v1.1.2 h1:wtRGZVv7olUHMOqouPpn3cXJWpJgM6+EUl31EQbXALQ=
 github.com/containernetworking/cni v1.1.2/go.mod h1:sDpYKmGVENF3s6uvMvGgldDWeG8dMxakj/u+i9ht9vw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -37,6 +35,8 @@ github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/mikezappa87/go-cni v1.1.1-0.20240114032345-d4b1b5a94b43 h1:rDQrR9kbCocx2IyDoaZm4zppYH01M1KbtMZP7qsTJYs=
+github.com/mikezappa87/go-cni v1.1.1-0.20240114032345-d4b1b5a94b43/go.mod h1:XYrZJ1d5W6E2VOvjffL3IZq0Dz6bsVlERHbekNK90PM=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/pkg/cni-service/kni.go
+++ b/pkg/cni-service/kni.go
@@ -12,42 +12,50 @@ import (
 	bolt "go.etcd.io/bbolt"
 )
 
+type KNIConfig struct {
+	UseMultiNet bool
+	IfPrefix    string
+	Db          string
+}
+
 type KniService struct {
-	c cni.CNI
-	store *bolt.DB
+	c      cni.CNI
+	store  *bolt.DB
+	config KNIConfig
 }
 
 type attachStore struct {
-	IP map[string]*beta.IPConfig
+	IP          map[string]*beta.IPConfig
 	Annotations map[string]string
 }
 
 const PodBucket = "pod"
 
-func NewKniService(ifprefix, dbname string) (beta.KNIServer, error) {
+func NewKniService(config *KNIConfig) (beta.KNIServer, error) {
 	log.Info("starting kni network runtime service")
-	
+
 	opts := []cni.Opt{
-		cni.WithInterfacePrefix(ifprefix),
-		 cni.WithDefaultConf,
-		 cni.WithLoNetwork} 
-	
+		cni.WithInterfacePrefix(config.IfPrefix),
+		cni.WithAllConf,
+		cni.WithLoNetwork}
+
 	cni, err := cni.New()
 
 	if err != nil {
 		return nil, err
 	}
-	
-	db, err := bolt.Open(dbname, 0600, nil)
+
+	db, err := bolt.Open(config.Db, 0600, nil)
 	if err != nil {
-  		return nil, err
+		return nil, err
 	}
 
 	log.Info("boltdb connection is open")
 
 	kni := &KniService{
-		c: cni,
-		store: db,
+		c:      cni,
+		store:  db,
+		config: *config,
 	}
 
 	db.Update(func(tx *bolt.Tx) error {
@@ -62,7 +70,7 @@ func NewKniService(ifprefix, dbname string) (beta.KNIServer, error) {
 
 	if err != nil {
 		return nil, err
-  	}
+	}
 
 	go func() {
 		sync.syncLoop()
@@ -76,7 +84,7 @@ func NewKniService(ifprefix, dbname string) (beta.KNIServer, error) {
 func (k *KniService) AttachNetwork(ctx context.Context, req *beta.AttachNetworkRequest) (*beta.AttachNetworkResponse, error) {
 	//This is nice. In the container runtime if you want to add one you need to contribute this to the container runtime
 	//This way you are in complete control. Better capability support with KNI -> CNI
-	
+
 	log.Infof("attach rpc request for id %s", req.Id)
 
 	opts := []cni.NamespaceOpts{
@@ -94,20 +102,32 @@ func (k *KniService) AttachNetwork(ctx context.Context, req *beta.AttachNetworkR
 		log.Infof("pod annotation id: %s netns: %s\n", req.Id, req.Isolation.Path)
 	} else {
 		log.Info("no network namespace path, this is either a bug or its running in the root")
-		return &beta.AttachNetworkResponse{
-		}, nil
+		return &beta.AttachNetworkResponse{}, nil
 	}
-	
-	res, err := k.c.SetupSerially(ctx, req.Id, req.Isolation.Path, opts...)
 
-	if err != nil {
-		log.Errorf("unable to execute CNI ADD: %s",err.Error())
+	var res *cni.Result
+	var err error
 
-		return nil, err
+	if k.config.UseMultiNet {
+		res, err = k.SetupMultipleNetworks(ctx, req)
+
+		if err != nil {
+			log.Errorf("unable to execute CNI ADD: %s", err.Error())
+
+			return nil, err
+		}
+	} else {
+		res, err = k.c.SetupSerially(ctx, req.Id, req.Isolation.Path, opts...)
+
+		if err != nil {
+			log.Errorf("unable to execute CNI ADD: %s", err.Error())
+
+			return nil, err
+		}
 	}
 
 	store := attachStore{
-		IP: make(map[string]*beta.IPConfig),
+		IP:          make(map[string]*beta.IPConfig),
 		Annotations: map[string]string{},
 	}
 
@@ -146,7 +166,7 @@ func (k *KniService) AttachNetwork(ctx context.Context, req *beta.AttachNetworkR
 
 		return b.Put([]byte(req.Id), js)
 	})
-	
+
 	if err != nil {
 		log.Errorf("unable to save record for id: %s: %s", req.Id, err.Error())
 		return nil, err
@@ -158,7 +178,7 @@ func (k *KniService) AttachNetwork(ctx context.Context, req *beta.AttachNetworkR
 }
 
 func (k *KniService) DetachNetwork(ctx context.Context, req *beta.DetachNetworkRequest) (*beta.DetachNetworkResponse, error) {
-	
+
 	log.Infof("detach rpc request for id %s", req.Id)
 
 	opts := []cni.NamespaceOpts{
@@ -170,7 +190,7 @@ func (k *KniService) DetachNetwork(ctx context.Context, req *beta.DetachNetworkR
 
 	err := k.store.View(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte(PodBucket))
-		
+
 		if b == nil {
 			return errors.New("bucket not created")
 		}
@@ -182,19 +202,29 @@ func (k *KniService) DetachNetwork(ctx context.Context, req *beta.DetachNetworkR
 		}
 
 		data := attachStore{}
-		
+
 		err := json.Unmarshal(v, &data)
 
 		if err != nil {
 			return err
 		}
 
-		err = k.c.Remove(ctx, req.Id, data.Annotations["netns"], opts...)
+		if k.config.UseMultiNet {
+			err = k.RemoveMultipleNetworks(ctx, req)
 
-		if err != nil {
-			log.Errorf("unable to execute CNI DEL: %s",err.Error())
+			if err != nil {
+				log.Errorf("unable to execute CNI DEL: %s", err.Error())
 
-			return err
+				return err
+			}
+		} else {
+			err = k.c.Remove(ctx, req.Id, data.Annotations["netns"], opts...)
+
+			if err != nil {
+				log.Errorf("unable to execute CNI DEL: %s", err.Error())
+
+				return err
+			}
 		}
 
 		return nil
@@ -206,13 +236,13 @@ func (k *KniService) DetachNetwork(ctx context.Context, req *beta.DetachNetworkR
 		return nil, err
 	}
 
-	err = k.store.Update(func (tx *bolt.Tx) error {
+	err = k.store.Update(func(tx *bolt.Tx) error {
 		b, err := tx.CreateBucketIfNotExists([]byte(PodBucket))
 
 		if err != nil {
 			return err
 		}
-		
+
 		return b.Delete([]byte(req.Id))
 	})
 
@@ -231,15 +261,15 @@ func (k *KniService) SetupNodeNetwork(context.Context, *beta.SetupNodeNetworkReq
 	return nil, nil
 }
 
-func (k *KniService) QueryPodNetwork(ctx context.Context,req *beta.QueryPodNetworkRequest) (*beta.QueryPodNetworkResponse, error) {
-	
+func (k *KniService) QueryPodNetwork(ctx context.Context, req *beta.QueryPodNetworkRequest) (*beta.QueryPodNetworkResponse, error) {
+
 	log.Infof("query pod rpc request id: %s", req.Id)
 
 	data := attachStore{}
-	
+
 	err := k.store.View(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte(PodBucket))
-		
+
 		if b == nil {
 			return errors.New("bucket not created")
 		}
@@ -249,7 +279,7 @@ func (k *KniService) QueryPodNetwork(ctx context.Context,req *beta.QueryPodNetwo
 		if v == nil {
 			return nil
 		}
-		
+
 		err := json.Unmarshal(v, &data)
 
 		if err != nil {
@@ -260,8 +290,7 @@ func (k *KniService) QueryPodNetwork(ctx context.Context,req *beta.QueryPodNetwo
 	})
 
 	if data.IP == nil {
-		return &beta.QueryPodNetworkResponse{
-		}, nil
+		return &beta.QueryPodNetworkResponse{}, nil
 	}
 
 	log.Infof("ipconfigs received for id: %s ip: %s", req.Id, data.IP)
@@ -280,17 +309,13 @@ func (k *KniService) QueryNodeNetworks(ctx context.Context, req *beta.QueryNodeN
 
 	if err := k.c.Status(); err != nil {
 		networks = append(networks, &beta.Network{
-			Name: "default",
-			Ready: false,
+			Name:      "default",
+			Ready:     false,
 			Extradata: map[string]string{},
 		})
-
-		return &beta.QueryNodeNetworksResponse{
-			Networks: networks,
-		}, nil
 	} else {
 		networks = append(networks, &beta.Network{
-			Name: "default",
+			Name:  "default",
 			Ready: true,
 		})
 	}
@@ -298,4 +323,48 @@ func (k *KniService) QueryNodeNetworks(ctx context.Context, req *beta.QueryNodeN
 	return &beta.QueryNodeNetworksResponse{
 		Networks: networks,
 	}, nil
+}
+
+func (k *KniService) SetupMultipleNetworks(ctx context.Context, req *beta.AttachNetworkRequest) (*cni.Result, error) {
+	x := extractNetworks(req.Annotations)
+
+	appendDefaultCNINetworks(&x, k.c)
+
+	networks, err := k.c.BuildMultiNetwork(x)
+
+	if err != nil {
+		return nil, err
+	}
+
+	opts := []cni.NamespaceOpts{}
+
+	res, err := k.c.SetupNetworks(ctx, req.Id, req.Isolation.Path, networks, opts...)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+func (k *KniService) RemoveMultipleNetworks(ctx context.Context, req *beta.DetachNetworkRequest) error {
+	x := extractNetworks(req.Annotations)
+
+	appendDefaultCNINetworks(&x, k.c)
+
+	networks, err := k.c.BuildMultiNetwork(x)
+
+	if err != nil {
+		return err
+	}
+
+	opts := []cni.NamespaceOpts{}
+
+	err = k.c.RemoveNetworks(ctx, req.Id, req.Isolation.Path, networks, opts...)
+
+	if err != nil {
+		return nil
+	}
+
+	return nil
 }

--- a/pkg/cni-service/kni.go
+++ b/pkg/cni-service/kni.go
@@ -360,7 +360,7 @@ func (k *KniService) RemoveMultipleNetworks(ctx context.Context, req *beta.Detac
 
 	opts := []cni.NamespaceOpts{}
 
-	err = k.c.RemoveNetworks(ctx, req.Id, req.Isolation.Path, networks, opts...)
+	err = k.c.RemoveNetworks(ctx, req.Id, req.Annotations["netns"], networks, opts...)
 
 	if err != nil {
 		return nil

--- a/pkg/cni-service/utils.go
+++ b/pkg/cni-service/utils.go
@@ -1,0 +1,42 @@
+package cniservice
+
+import (
+	"strings"
+
+	"github.com/containerd/go-cni"
+)
+
+func appendDefaultCNINetworks(net *[]*cni.NetworkInterface, plugin cni.CNI) {
+	*net = append(*net, &cni.NetworkInterface{
+		NetworkName:   "cni-loopback",
+		InterfaceName: "lo",
+	},
+		&cni.NetworkInterface{
+			InterfaceName: "eth0",
+			//Index 0 and 1 should always be here
+			NetworkName: plugin.GetConfig().Networks[1].Config.Name,
+		})
+}
+
+func extractNetworks(annotations map[string]string) []*cni.NetworkInterface {
+	var x []*cni.NetworkInterface
+
+	if val, ok := annotations["kni.io/multi-network"]; ok {
+		for _, value := range strings.Split(val, ",") {
+			if strings.Contains(value, "@") {
+				a := strings.Split(value, "@")
+
+				x = append(x, &cni.NetworkInterface{
+					NetworkName:   a[0],
+					InterfaceName: a[1],
+				})
+			} else {
+				x = append(x, &cni.NetworkInterface{
+					NetworkName: value,
+				})
+			}
+		}
+	}
+
+	return x
+}

--- a/pkg/cni-service/utils.go
+++ b/pkg/cni-service/utils.go
@@ -7,15 +7,16 @@ import (
 )
 
 func appendDefaultCNINetworks(net *[]*cni.NetworkInterface, plugin cni.CNI) {
-	*net = append(*net, &cni.NetworkInterface{
-		NetworkName:   "cni-loopback",
-		InterfaceName: "lo",
-	},
+	*net = append([]*cni.NetworkInterface{
+		&cni.NetworkInterface{
+			NetworkName:   "cni-loopback",
+			InterfaceName: "lo",
+		},
 		&cni.NetworkInterface{
 			InterfaceName: "eth0",
 			//Index 0 and 1 should always be here
 			NetworkName: plugin.GetConfig().Networks[1].Config.Name,
-		})
+		}}, *net...)
 }
 
 func extractNetworks(annotations map[string]string) []*cni.NetworkInterface {


### PR DESCRIPTION
This fix resort network interfaces slice to make lo/eth0 as first element and put other interfaces later on eth0.